### PR TITLE
Modified NormalizedAmplitudeToNumber and added FloatArrayToGraph

### DIFF
--- a/examples/new_nodes_example.json
+++ b/examples/new_nodes_example.json
@@ -1,0 +1,847 @@
+{
+  "last_node_id": 53,
+  "last_link_id": 70,
+  "nodes": [
+    {
+      "id": 10,
+      "type": "LoadAudio",
+      "pos": [
+        -270,
+        790
+      ],
+      "size": {
+        "0": 315,
+        "1": 82
+      },
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "outputs": [
+        {
+          "name": "AUDIO",
+          "type": "AUDIO",
+          "links": [
+            10
+          ],
+          "shape": 3,
+          "slot_index": 0
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadAudio"
+      },
+      "widgets_values": [
+        "everything_3.wav",
+        "Audio"
+      ]
+    },
+    {
+      "id": 50,
+      "type": "NormalizeAmplitude",
+      "pos": [
+        1120,
+        1070
+      ],
+      "size": {
+        "0": 315,
+        "1": 58
+      },
+      "flags": {},
+      "order": 8,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "amplitude",
+          "type": "AMPLITUDE",
+          "link": 70
+        }
+      ],
+      "outputs": [
+        {
+          "name": "normalized_amp",
+          "type": "NORMALIZED_AMPLITUDE",
+          "links": [
+            66
+          ],
+          "shape": 3,
+          "slot_index": 0
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "NormalizeAmplitude"
+      },
+      "widgets_values": [
+        false
+      ]
+    },
+    {
+      "id": 51,
+      "type": "NormalizedAmplitudeToNumber",
+      "pos": [
+        1470,
+        1080
+      ],
+      "size": {
+        "0": 315,
+        "1": 126
+      },
+      "flags": {},
+      "order": 12,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "normalized_amp",
+          "type": "NORMALIZED_AMPLITUDE",
+          "link": 66
+        }
+      ],
+      "outputs": [
+        {
+          "name": "FLOAT",
+          "type": "FLOAT",
+          "links": [
+            67
+          ],
+          "shape": 3,
+          "slot_index": 0
+        },
+        {
+          "name": "INT",
+          "type": "INT",
+          "links": null,
+          "shape": 3
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "NormalizedAmplitudeToNumber"
+      },
+      "widgets_values": [
+        0,
+        0,
+        1
+      ]
+    },
+    {
+      "id": 53,
+      "type": "PreviewImage",
+      "pos": [
+        1800,
+        1180
+      ],
+      "size": {
+        "0": 317.6799011230469,
+        "1": 246
+      },
+      "flags": {},
+      "order": 17,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 68
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "PreviewImage"
+      }
+    },
+    {
+      "id": 52,
+      "type": "FloatArrayToGraph",
+      "pos": [
+        1800,
+        1090
+      ],
+      "size": {
+        "0": 315,
+        "1": 58
+      },
+      "flags": {},
+      "order": 16,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "float_array",
+          "type": "FLOAT",
+          "link": 67,
+          "widget": {
+            "name": "float_array"
+          }
+        }
+      ],
+      "outputs": [
+        {
+          "name": "graph_image",
+          "type": "IMAGE",
+          "links": [
+            68
+          ],
+          "shape": 3,
+          "slot_index": 0
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "FloatArrayToGraph"
+      },
+      "widgets_values": [
+        0
+      ]
+    },
+    {
+      "id": 31,
+      "type": "FloatArrayToGraph",
+      "pos": [
+        1550,
+        270
+      ],
+      "size": {
+        "0": 315,
+        "1": 58
+      },
+      "flags": {},
+      "order": 9,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "float_array",
+          "type": "FLOAT",
+          "link": 56,
+          "widget": {
+            "name": "float_array"
+          }
+        }
+      ],
+      "outputs": [
+        {
+          "name": "graph_image",
+          "type": "IMAGE",
+          "links": [
+            53
+          ],
+          "shape": 3,
+          "slot_index": 0
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "FloatArrayToGraph"
+      },
+      "widgets_values": [
+        0
+      ]
+    },
+    {
+      "id": 40,
+      "type": "PreviewImage",
+      "pos": [
+        1550,
+        360
+      ],
+      "size": {
+        "0": 314.0111389160156,
+        "1": 246
+      },
+      "flags": {},
+      "order": 13,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 53
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "PreviewImage"
+      }
+    },
+    {
+      "id": 46,
+      "type": "FloatArrayToGraph",
+      "pos": [
+        1550,
+        640
+      ],
+      "size": {
+        "0": 315,
+        "1": 58
+      },
+      "flags": {},
+      "order": 10,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "float_array",
+          "type": "FLOAT",
+          "link": 60,
+          "widget": {
+            "name": "float_array"
+          }
+        }
+      ],
+      "outputs": [
+        {
+          "name": "graph_image",
+          "type": "IMAGE",
+          "links": [
+            61
+          ],
+          "shape": 3,
+          "slot_index": 0
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "FloatArrayToGraph"
+      },
+      "widgets_values": [
+        0
+      ]
+    },
+    {
+      "id": 47,
+      "type": "PreviewImage",
+      "pos": [
+        1550,
+        730
+      ],
+      "size": {
+        "0": 315.7936706542969,
+        "1": 246
+      },
+      "flags": {},
+      "order": 14,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 61
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "PreviewImage"
+      }
+    },
+    {
+      "id": 45,
+      "type": "FloatArrayToGraph",
+      "pos": [
+        1550,
+        -100
+      ],
+      "size": {
+        "0": 315,
+        "1": 58
+      },
+      "flags": {},
+      "order": 11,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "float_array",
+          "type": "FLOAT",
+          "link": 62,
+          "widget": {
+            "name": "float_array"
+          }
+        }
+      ],
+      "outputs": [
+        {
+          "name": "graph_image",
+          "type": "IMAGE",
+          "links": [
+            63
+          ],
+          "shape": 3,
+          "slot_index": 0
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "FloatArrayToGraph"
+      },
+      "widgets_values": [
+        0
+      ]
+    },
+    {
+      "id": 12,
+      "type": "BatchAmplitudeSchedule",
+      "pos": [
+        410,
+        780
+      ],
+      "size": {
+        "0": 315,
+        "1": 106
+      },
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "audio_fft",
+          "type": "AUDIO_FFT",
+          "link": 11
+        }
+      ],
+      "outputs": [
+        {
+          "name": "amplitude",
+          "type": "AMPLITUDE",
+          "links": [
+            14,
+            64
+          ],
+          "shape": 3,
+          "slot_index": 0
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "BatchAmplitudeSchedule"
+      },
+      "widgets_values": [
+        "max",
+        350,
+        1200
+      ]
+    },
+    {
+      "id": 11,
+      "type": "AudioToFFTs",
+      "pos": [
+        70,
+        790
+      ],
+      "size": {
+        "0": 315,
+        "1": 150
+      },
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "audio",
+          "type": "AUDIO",
+          "link": 10
+        }
+      ],
+      "outputs": [
+        {
+          "name": "AUDIO_FFT",
+          "type": "AUDIO_FFT",
+          "links": [
+            11
+          ],
+          "shape": 3,
+          "slot_index": 0
+        },
+        {
+          "name": "total_frames",
+          "type": "INT",
+          "links": null,
+          "shape": 3
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "AudioToFFTs"
+      },
+      "widgets_values": [
+        0,
+        12,
+        0,
+        80
+      ]
+    },
+    {
+      "id": 16,
+      "type": "NormalizeAmplitude",
+      "pos": [
+        810,
+        460
+      ],
+      "size": {
+        "0": 315,
+        "1": 58
+      },
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "amplitude",
+          "type": "AMPLITUDE",
+          "link": 14
+        }
+      ],
+      "outputs": [
+        {
+          "name": "normalized_amp",
+          "type": "NORMALIZED_AMPLITUDE",
+          "links": [
+            54,
+            58,
+            59
+          ],
+          "shape": 3,
+          "slot_index": 0
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "NormalizeAmplitude"
+      },
+      "widgets_values": [
+        false
+      ]
+    },
+    {
+      "id": 43,
+      "type": "NormalizedAmplitudeToNumber",
+      "pos": [
+        1230,
+        -100
+      ],
+      "size": {
+        "0": 315,
+        "1": 126
+      },
+      "flags": {},
+      "order": 7,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "normalized_amp",
+          "type": "NORMALIZED_AMPLITUDE",
+          "link": 59
+        }
+      ],
+      "outputs": [
+        {
+          "name": "FLOAT",
+          "type": "FLOAT",
+          "links": [
+            62
+          ],
+          "shape": 3,
+          "slot_index": 0
+        },
+        {
+          "name": "INT",
+          "type": "INT",
+          "links": null,
+          "shape": 3
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "NormalizedAmplitudeToNumber"
+      },
+      "widgets_values": [
+        0.1,
+        0,
+        1
+      ]
+    },
+    {
+      "id": 49,
+      "type": "ClipAmplitude",
+      "pos": [
+        770,
+        1070
+      ],
+      "size": {
+        "0": 315,
+        "1": 82
+      },
+      "flags": {},
+      "order": 4,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "amplitude",
+          "type": "AMPLITUDE",
+          "link": 64
+        }
+      ],
+      "outputs": [
+        {
+          "name": "amplitude",
+          "type": "AMPLITUDE",
+          "links": [
+            70
+          ],
+          "shape": 3,
+          "slot_index": 0
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "ClipAmplitude"
+      },
+      "widgets_values": [
+        560,
+        500
+      ]
+    },
+    {
+      "id": 44,
+      "type": "NormalizedAmplitudeToNumber",
+      "pos": [
+        1230,
+        640
+      ],
+      "size": {
+        "0": 315,
+        "1": 126
+      },
+      "flags": {},
+      "order": 6,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "normalized_amp",
+          "type": "NORMALIZED_AMPLITUDE",
+          "link": 58
+        }
+      ],
+      "outputs": [
+        {
+          "name": "FLOAT",
+          "type": "FLOAT",
+          "links": [
+            60
+          ],
+          "shape": 3,
+          "slot_index": 0
+        },
+        {
+          "name": "INT",
+          "type": "INT",
+          "links": null,
+          "shape": 3
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "NormalizedAmplitudeToNumber"
+      },
+      "widgets_values": [
+        0.75,
+        0.25,
+        2
+      ]
+    },
+    {
+      "id": 48,
+      "type": "PreviewImage",
+      "pos": [
+        1549,
+        -10
+      ],
+      "size": {
+        "0": 317.6799011230469,
+        "1": 246
+      },
+      "flags": {},
+      "order": 15,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 63
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "PreviewImage"
+      }
+    },
+    {
+      "id": 41,
+      "type": "NormalizedAmplitudeToNumber",
+      "pos": [
+        1230,
+        270
+      ],
+      "size": {
+        "0": 315,
+        "1": 126
+      },
+      "flags": {},
+      "order": 5,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "normalized_amp",
+          "type": "NORMALIZED_AMPLITUDE",
+          "link": 54
+        }
+      ],
+      "outputs": [
+        {
+          "name": "FLOAT",
+          "type": "FLOAT",
+          "links": [
+            56
+          ],
+          "shape": 3,
+          "slot_index": 0
+        },
+        {
+          "name": "INT",
+          "type": "INT",
+          "links": null,
+          "shape": 3
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "NormalizedAmplitudeToNumber"
+      },
+      "widgets_values": [
+        0.35000000000000003,
+        0,
+        1
+      ]
+    }
+  ],
+  "links": [
+    [
+      10,
+      10,
+      0,
+      11,
+      0,
+      "AUDIO"
+    ],
+    [
+      11,
+      11,
+      0,
+      12,
+      0,
+      "AUDIO_FFT"
+    ],
+    [
+      14,
+      12,
+      0,
+      16,
+      0,
+      "AMPLITUDE"
+    ],
+    [
+      53,
+      31,
+      0,
+      40,
+      0,
+      "IMAGE"
+    ],
+    [
+      54,
+      16,
+      0,
+      41,
+      0,
+      "NORMALIZED_AMPLITUDE"
+    ],
+    [
+      56,
+      41,
+      0,
+      31,
+      0,
+      "FLOAT"
+    ],
+    [
+      58,
+      16,
+      0,
+      44,
+      0,
+      "NORMALIZED_AMPLITUDE"
+    ],
+    [
+      59,
+      16,
+      0,
+      43,
+      0,
+      "NORMALIZED_AMPLITUDE"
+    ],
+    [
+      60,
+      44,
+      0,
+      46,
+      0,
+      "FLOAT"
+    ],
+    [
+      61,
+      46,
+      0,
+      47,
+      0,
+      "IMAGE"
+    ],
+    [
+      62,
+      43,
+      0,
+      45,
+      0,
+      "FLOAT"
+    ],
+    [
+      63,
+      45,
+      0,
+      48,
+      0,
+      "IMAGE"
+    ],
+    [
+      64,
+      12,
+      0,
+      49,
+      0,
+      "AMPLITUDE"
+    ],
+    [
+      66,
+      50,
+      0,
+      51,
+      0,
+      "NORMALIZED_AMPLITUDE"
+    ],
+    [
+      67,
+      51,
+      0,
+      52,
+      0,
+      "FLOAT"
+    ],
+    [
+      68,
+      52,
+      0,
+      53,
+      0,
+      "IMAGE"
+    ],
+    [
+      70,
+      49,
+      0,
+      50,
+      0,
+      "AMPLITUDE"
+    ]
+  ],
+  "groups": [],
+  "config": {},
+  "extra": {},
+  "version": 0.4
+}

--- a/nodes.py
+++ b/nodes.py
@@ -515,9 +515,9 @@ class AmplitudeToNumber:
     def convert(self, amplitude,):
         return (amplitude.astype(float), amplitude.astype(int))
 
-class AmplitudeToFloat:
+class NormalizedAmplitudeToNumber:
     @classmethod
-    def INPUT_TYPES(s):
+    def INPUT_TYPES(cls):
         return {
             "required": {
                 "normalized_amp": ("NORMALIZED_AMPLITUDE",),
@@ -529,7 +529,7 @@ class AmplitudeToFloat:
 
     CATEGORY = "AudioScheduler/Amplitude"
 
-    RETURN_TYPES = ("FLOAT",)
+    RETURN_TYPES = ("FLOAT", "INT")
     FUNCTION = "convert"
 
     def convert(self, normalized_amp, add_to, threshold_for_add, add_ceiling):
@@ -541,8 +541,8 @@ class AmplitudeToFloat:
 
         # Clip the result to the add_ceiling
         modified_values = np.clip(modified_values, 0.0, add_ceiling)
-        
-        return modified_values
+
+        return modified_values, modified_values.astype(int)
 
 class AmplitudeToGraph:
     @classmethod
@@ -640,7 +640,6 @@ class FloatArrayToGraph:
         image = Image.open(buffer)
 
         return (pil2tensor(image),)
-    
 
 NODE_CLASS_MAPPINGS = {
     "LoadAudio": LoadAudio,
@@ -652,7 +651,6 @@ NODE_CLASS_MAPPINGS = {
     "TransientAmplitudeBasic": TransientAmplitudeBasic,
     "AmplitudeToNumber" : AmplitudeToNumber,
     "AmplitudeToGraph" : AmplitudeToGraph,
-    "AmplitudeToFloat" : AmplitudeToFloat,
     "FloatArrayToGraph" : FloatArrayToGraph,
     # Normalized Amplitude
     "NormalizeAmplitude": NormalizeAmplitude,
@@ -671,7 +669,6 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "TransientAmplitudeBasic": "Transient Amplitude Basic",
     "AmplitudeToNumber" : "Amplitude To Float or Int",
     "AmplitudeToGraph" : "Amplitude To Graph",
-    "AmplitudeToFloat" : "Amplitude To Float",
     "FloatArrayToGraph" : "Float Array To Graph",
     # Normalized Amplitude
     "NormalizeAmplitude": "Normalize Amplitude",

--- a/nodes.py
+++ b/nodes.py
@@ -515,6 +515,34 @@ class AmplitudeToNumber:
     def convert(self, amplitude,):
         return (amplitude.astype(float), amplitude.astype(int))
 
+class AmplitudeToFloat:
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": {
+                "normalized_amp": ("NORMALIZED_AMPLITUDE",),
+                "add_to": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 4.0, "step": 0.05}),
+                "threshold_for_add": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 1.0, "step": 0.01}),
+                "add_ceiling": ("FLOAT", {"default": 1.0, "min": 0.1, "max": 4.0, "step": 0.1}),
+            },
+        }
+
+    CATEGORY = "AudioScheduler/Amplitude"
+
+    RETURN_TYPES = ("FLOAT",)
+    FUNCTION = "convert"
+
+    def convert(self, normalized_amp, add_to, threshold_for_add, add_ceiling):
+        normalized_amp[np.isnan(normalized_amp)] = 0.0
+        normalized_amp[np.isinf(normalized_amp)] = 1.0
+
+        # Conditionally add add_to only if value is above threshold_for_add
+        modified_values = np.where(normalized_amp > threshold_for_add, normalized_amp + add_to, normalized_amp)
+
+        # Clip the result to the add_ceiling
+        modified_values = np.clip(modified_values, 0.0, add_ceiling)
+        
+        return modified_values
 
 class AmplitudeToGraph:
     @classmethod
@@ -559,6 +587,59 @@ class AmplitudeToGraph:
         image = Image.open(buffer)
 
         return (pil2tensor(image),)
+
+class FloatArrayToGraph:
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": {
+                "float_array": ("FLOAT", {"array": True}),
+            },
+        }
+
+    CATEGORY = "AudioScheduler/Amplitude"
+
+    RETURN_TYPES = ("IMAGE",)
+    RETURN_NAMES = ("graph_image",)
+    FUNCTION = "graph"
+
+    def graph(self, float_array=None):
+        # If float_array is not provided, you can handle it as needed
+        if float_array is None:
+            raise ValueError("Float array must be provided.")
+
+        # Convert a single float into a one-element array
+        if not isinstance(float_array, np.ndarray):
+            float_array = np.array([float_array])
+
+        width = int(len(float_array) / 10)
+        if width < 10:
+            width = 10
+        if width > 100:
+            width = 100
+        
+        plt.figure(figsize=(width, 6))
+        plt.plot(float_array,)
+
+        # Prevent scientific notation on the y-axis
+        plt.ticklabel_format(axis='y', style='plain')
+
+        plt.xlabel("Frame(s)")
+        plt.ylabel("Amplitude")
+        plt.legend()
+        plt.grid()
+
+        # Create an in-memory buffer to store the image
+        buffer = BytesIO()
+
+        # Save the plot to the in-memory buffer as a PNG
+        plt.savefig(buffer, format="png")
+        buffer.seek(0)
+
+        # Create a Pillow Image object
+        image = Image.open(buffer)
+
+        return (pil2tensor(image),)
     
 
 NODE_CLASS_MAPPINGS = {
@@ -571,6 +652,8 @@ NODE_CLASS_MAPPINGS = {
     "TransientAmplitudeBasic": TransientAmplitudeBasic,
     "AmplitudeToNumber" : AmplitudeToNumber,
     "AmplitudeToGraph" : AmplitudeToGraph,
+    "AmplitudeToFloat" : AmplitudeToFloat,
+    "FloatArrayToGraph" : FloatArrayToGraph,
     # Normalized Amplitude
     "NormalizeAmplitude": NormalizeAmplitude,
     "GateNormalizedAmplitude": GateNormalizedAmplitude,
@@ -588,6 +671,8 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "TransientAmplitudeBasic": "Transient Amplitude Basic",
     "AmplitudeToNumber" : "Amplitude To Float or Int",
     "AmplitudeToGraph" : "Amplitude To Graph",
+    "AmplitudeToFloat" : "Amplitude To Float",
+    "FloatArrayToGraph" : "Float Array To Graph",
     # Normalized Amplitude
     "NormalizeAmplitude": "Normalize Amplitude",
     "GateNormalizedAmplitude": "Gate Normalized Amplitude",


### PR DESCRIPTION
Modified the Normalized Amplitude to Float or Int node to include an add_to, threshold_for_add, and add_ceiling inputs.
Purpose: I wanted more control over the output float values used in the full_example workflow. This provides control over adding float amount to the output float of each frame, conditionally based on threshold, and having a ceiling so you can 'clip' amplitude effectively after it's normalized in float form.

Added FloatArrayToGraph as basically a clone of the other graph outputs, but for an array of floats.

workflow included.